### PR TITLE
fix: add missing type field to hook definitions (#1)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -41,6 +41,7 @@
         "matcher": "Bash",
         "hooks": [
           {
+            "type": "command",
             "command": "python .claude/reference/hooks/bash-safety.py"
           }
         ]
@@ -49,6 +50,7 @@
         "matcher": "Write|Edit",
         "hooks": [
           {
+            "type": "command",
             "command": "python .claude/reference/hooks/security-check.py"
           }
         ]
@@ -57,6 +59,7 @@
         "matcher": "Bash",
         "hooks": [
           {
+            "type": "command",
             "command": "python .claude/reference/hooks/validate-pr-template.py"
           }
         ]
@@ -65,6 +68,7 @@
         "matcher": "mcp__github__create_pull_request",
         "hooks": [
           {
+            "type": "command",
             "command": "python .claude/reference/hooks/validate-pr-template.py"
           }
         ]
@@ -73,6 +77,7 @@
         "matcher": "Bash",
         "hooks": [
           {
+            "type": "command",
             "command": "python .claude/reference/hooks/require-fresh-eyes-review.py"
           }
         ]
@@ -81,6 +86,7 @@
         "matcher": "mcp__github__merge_pull_request",
         "hooks": [
           {
+            "type": "command",
             "command": "python .claude/reference/hooks/require-fresh-eyes-review.py"
           }
         ]
@@ -91,6 +97,7 @@
         "matcher": "Write|Edit|Bash",
         "hooks": [
           {
+            "type": "command",
             "command": "python .claude/reference/hooks/validate-self-review.py"
           }
         ]


### PR DESCRIPTION
Closes #1

## Summary
- All 7 hook entries in `.claude/settings.local.json` were missing the required `"type": "command"` field
- Claude Code hooks fail at runtime without this field
- Downstream projects (e.g. Playlist100) required manual correction after scaffolding

## Self-Review

### Checklist Verified
- [x] Security (secrets, injection, auth bypass)
- [x] Correctness (logic errors, null refs, race conditions)
- [x] Logic flow (control flow, state transitions, algorithms)
- [x] User impact (functionality, performance)
- [x] Best practices (error handling, architecture)

### Findings
**Issues Found:** None

**Suggestions for Future:** None

### Self-Review Status
- [x] Ready for external review - No blocking issues found

## Test Plan
- [x] Verified hooks work correctly after adding the field in downstream project (Playlist100)

---
Generated with [Claude Code](https://claude.com/claude-code)