### PR TITLE
fix: add missing /ship pipeline steps to developer README (Closes #6)

### DIFF
--- a/.claude/developer/README.md
+++ b/.claude/developer/README.md
@@ -82,6 +82,18 @@ If the review finds blocking issues, the AI fixes them and runs review again. It
 
 **Command:** `/post-fresh-eyes-review`
 
+### Deferred Issues
+
+If the review identified non-blocking improvements, the AI creates GitHub issues to capture them. This ensures feedback is not lost without blocking the current PR.
+
+**Command:** `/create-deferred-issues`
+
+### Verify CI
+
+The AI checks that CI passes and there are no blockers before merging.
+
+**Command:** `/verify-pr-ready`
+
 ### Merge
 
 When reviews pass and CI is green, the AI merges the pull request. It uses squash merge to keep history clean.
@@ -98,7 +110,7 @@ One command runs the entire ship process:
 /ship
 ```
 
-This runs: self-review → create PR → external review → merge
+This runs: self-review → create PR → external review → deferred issues → verify CI → merge
 
 ## Running the Loop
 
@@ -138,7 +150,7 @@ The AI adapts. It does not get frustrated or confused.
 | `/next-issue` | Pick and start the next issue |
 | `/self-review` | Review current changes |
 | `/create-pr` | Push and create pull request |
-| `/ship` | Full workflow: review → PR → merge |
+| `/ship` | Full workflow: review → PR → external review → deferred issues → verify → merge |
 | `/block-issue` | Mark current issue as blocked, move on |
 
 [Full command reference](commands.md)


### PR DESCRIPTION
## Closes #6

## Summary
- Add missing `/create-deferred-issues` and `/verify-pr-ready` steps to developer README's `/ship` description
- Add new "Deferred Issues" and "Verify CI" sections between External Review and Merge
- Update summary line and commands reference table to show all 6 pipeline steps

## Self-Review

### Checklist Verified
- [x] Security (documentation-only change, no code)
- [x] Correctness (pipeline description now matches ship.md exactly)
- [x] Logic flow (new sections placed in correct order)
- [x] User impact (readers get complete picture of the pipeline)
- [x] Best practices (follows existing section format)

### Findings
**Issues Found:** None

**Suggestions for Future:** None

### Self-Review Status
- [x] Ready for external review - No blocking issues found

## Test Plan
- [x] Build succeeds (all hooks compile)
- [x] Verified pipeline description matches ship.md line 11
- [x] Verified no other sections were modified (AC-3)

---
Generated with [Claude Code](https://claude.com/claude-code)