### PR TITLE
fix: align README conventions table with actual template heading (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The framework commands reference standardized sections in your project's `CLAUDE
 | `## Build Commands` | `/self-review`, `/ship` | Yes |
 | `## Critical Rules` | `/self-review` (architecture checklist) | Yes |
 | `## Architecture` | Personas (project context) | Yes |
-| `## Testing Guidelines` | `/self-review` (test appropriateness) | Recommended |
+| `### 3. TEST APPROPRIATELY` (under Critical Rules) | `/self-review` (test appropriateness) | Yes (included in template) |
 | `## Autonomous Work Mode` | `/next-issue` | Optional |
 
 See `CLAUDE.md.template` for the full template.


### PR DESCRIPTION
## Closes #9

## Summary
- Updated README.md conventions table to reference `### 3. TEST APPROPRIATELY` (under Critical Rules) instead of nonexistent `## Testing Guidelines` section
- Changed "Required?" from "Recommended" to "Yes (included in template)" since the heading already exists in CLAUDE.md.template

## Self-Review

### Checklist Verified
- [x] Security (secrets, injection, auth bypass)
- [x] Correctness (logic errors, null refs, race conditions)
- [x] Logic flow (control flow, state transitions, algorithms)
- [x] User impact (functionality, performance)
- [x] Best practices (error handling, architecture)

### Findings
**Issues Found:** None

**Suggestions for Future:** None

### Self-Review Status
- [x] Ready for external review - No blocking issues found

## Test Plan
- [x] Build succeeds (all Python hooks compile)
- [x] Verified `### 3. TEST APPROPRIATELY` heading exists at line 32 of CLAUDE.md.template
- [x] Verified all other convention table sections still match template headings (AC-3)

---
Generated with [Claude Code](https://claude.com/claude-code)