### PR TITLE
fix: replace 'git add -A' with specific file staging in block-issue.md (#14)

### DIFF
--- a/.claude/commands/block-issue.md
+++ b/.claude/commands/block-issue.md
@@ -57,7 +57,8 @@ Before committing WIP, the build MUST pass. Run the build command from CLAUDE.md
 Only if there's meaningful progress to preserve:
 
 ```bash
-git add -A
+# Stage specific files you changed (avoid 'git add -A' which may stage secrets)
+git add <files-you-changed>
 git commit -m "wip: [brief description of progress] (#ISSUE_NUMBER)
 
 Work in progress - issue blocked.


### PR DESCRIPTION
## Closes #14

## Summary
- Replaced `git add -A` with `git add <files-you-changed>` in block-issue.md Step 2 (WIP commit)
- Added comment explaining why (`git add -A` may stage secrets like `.env`, `credentials.json`)

## Self-Review

### Checklist Verified
- [x] Security (secrets, injection, auth bypass)
- [x] Correctness (logic errors, null refs, race conditions)
- [x] Logic flow (control flow, state transitions, algorithms)
- [x] User impact (functionality, performance)
- [x] Best practices (error handling, architecture)

### Findings
**Issues Found:** None

**Suggestions for Future:** None

### Self-Review Status
- [x] Ready for external review - No blocking issues found

## Test Plan
- [x] Build succeeds (all Python hooks compile)
- [x] Verified no other framework files use `git add -A` or `git add .` (only occurrence was this one)
- [x] Block-issue WIP commit flow still reads correctly (AC-4)

---
Generated with [Claude Code](https://claude.com/claude-code)